### PR TITLE
Misc updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,3 +38,15 @@ iocBoot_DEPEND_DIRS += $(filter %App,$(DIRS))
 # Add any additional dependency rules here:
 
 include $(TOP)/configure/RULES_TOP
+
+ifeq ($(BUILD_IOCS), YES)
+uninstall: uninstall_iocs
+uninstall_iocs:
+	$(MAKE) -C iocs uninstall
+.PHONY: uninstall uninstall_iocs
+ 
+realuninstall: realuninstall_iocs
+realuninstall_iocs:
+	$(MAKE) -C iocs realuninstall
+.PHONY: realuninstall realuninstall_iocs
+endif

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # EPICS hwmon example
 
-Sample IOC that monitors CPU usage through sysfs.
+Sample device support module and test IOC that monitors CPU usage through sysfs on Linux.
 
-Supported platforms:
+Supported hardware:
 - Intel x86 processors via the 'coretemp' hwmon driver
 - AMD x86 processors (k10 and later) via the 'k10temp' hwmon driver
 - Raspberry Pi via the 'cpu\_thermal' hwmon driver
@@ -14,15 +14,67 @@ Demonstrates the following EPICS concepts:
 - Alarm management in device support code
 - Simple IOC application that uses the custom device support
 
-## Creating a new app
+## Building
 
+NOTE: This guide assumes you have already followed the environment setup guide on Confluence.
+
+First, generate RELEASE\_SITE:
+```sh
+$ epics-update -r
 ```
-# Create temperature monitor device support
-makeBaseApp.pl -t support tempMonApp
 
-# Create IOC application
-makeBaseApp.pl -t ioc tempMonIoc
-
-# Create IOC boot directories
-makeBaseApp.pl -i temp-mon-test
+If you're building this locally on a system that doesn't have `epics-update`, you should create a RELEASE\_SITE that looks like this:
+```makefile
+# Absolute path to the EPICS modules directory
+EPICS_MODULES=/path/to/epics/modules
+# This may also be empty if you're not using a version subdirectory
+BASE_MODULE_VERSION=R7.0.3.1
+# Should point to the top of the EPICS installation area
+EPICS_SITE_TOP=/path/to/epics
 ```
+
+After creating the RELEASE\_SITE, run:
+```sh
+$ make
+```
+
+If you want to build the example IOC along with the device support module, run:
+```sh
+$ make BUILD_IOCS=YES
+```
+
+## Running the IOC
+
+After running `make BUILD_IOCS=YES`, the IOC can be launched with:
+```sh
+$ cd iocs/tempMonExampleIoc/iocBoot/sioc-temp-mon-test
+$ ../../bin/$EPICS_HOST_ARCH/tempMonIoc st.cmd
+```
+
+For convenience, I provided a script called `ioc.sh` that runs the IOC for you:
+```sh
+$ ./ioc.sh
+```
+
+## Launching PyDM Screens
+
+### Installing PyDM
+
+PyDM can be installed through conda with the following command:
+```sh
+$ conda create -n pydm-environment python=3.10 pyqt=5.12.3 pydm -c conda-forge
+```
+PyQt is pinned to 5.12.3 here per recommendation by the PyDM maintainers. If you don't pin it, Qt designer will not have PyDM widgets in it.
+If you don't plan on using Qt designer to create new screens this isn't a big deal.
+
+The new environment can be activated using `conda activate pydm-environment`
+
+### Launching Screens
+
+The screen can be launched by either using `launch-screen.sh`, or with the following command:
+```sh
+$ pydm -m "P=MYIOC:" ./tempMonApp/op/pydm/cpu_temp.ui
+```
+
+The `-m` argument provides a list of macro substitutions. In our case, the macro `P` corresponds
+to the PV prefix we put on the record. This matches the value we passed to dbLoadRecords in iocBoot.

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -1,48 +1,43 @@
-# SPDX-FileCopyrightText: 1997 Argonne National Laboratory
+# RELEASE.local
 #
-# SPDX-License-Identifier: EPICS
-
-# RELEASE - Location of external support modules
-#
-# IF YOU CHANGE ANY PATHS in this file or make API changes to
-# any modules it refers to, you should do a "make rebuild" in
-# this application's top level directory.
-#
-# The EPICS build process does not check dependencies against
-# any files from outside the application, so it is safest to
-# rebuild it completely if any modules it depends on change.
-#
-# Host- or target-specific settings can be given in files named
-#  RELEASE.$(EPICS_HOST_ARCH).Common
-#  RELEASE.Common.$(T_A)
-#  RELEASE.$(EPICS_HOST_ARCH).$(T_A)
-#
-# This file is parsed by both GNUmake and an EPICS Perl script,
-# so it may ONLY contain definititions of paths to other support
-# modules, variable definitions that are used in module paths,
-# and include statements that pull in other RELEASE files.
-# Variables may be used before their values have been set.
-# Build variables that are NOT used in paths should be set in
-# the CONFIG_SITE file.
-
-# Variables and paths to dependent modules:
-#MODULES = /path/to/modules
-#MYMODULE = $(MODULES)/my-module
-
-# If using the sequencer, point SNCSEQ at its top directory:
-#SNCSEQ = $(MODULES)/seq-ver
-
-# EPICS_BASE should appear last so earlier modules can override stuff:
-
-# Set RULES here if you want to use build rules from somewhere
-# other than EPICS_BASE:
-#RULES = $(MODULES)/build-rules
-
-# These lines allow developers to override these RELEASE settings
-# without having to modify this file directly.
--include $(TOP)/../RELEASE.local
--include $(TOP)/../RELEASE.$(EPICS_HOST_ARCH).local
--include $(TOP)/configure/RELEASE.local
-
+# Read definitions of:
+#	EPICS_SITE_TOP
+#	BASE_MODULE_VERSION
+#	EPICS_MODULES 
+# from one of the following options
 -include $(TOP)/../../RELEASE_SITE
 -include $(TOP)/RELEASE_SITE
+
+# Check that EPICS_MODULES was defined in a RELEASE_SITE file
+-include $(TOP)/../../RELEASE_SITE.check
+
+# ==========================================================
+# Define the version strings for all needed modules
+# Use naming pattern:
+#   FOO_MODULE_VERSION = R1.2
+# so scripts can extract version strings
+# Don't set your version to anything such as "test" that
+# could match a directory name.
+# ==========================================================
+#MY_MODULE_VERSION=R4.39-1.0.2
+
+# ==========================================================
+# External Support module path definitions
+#
+# If any of these macros expand to a path which
+# contains an "include" directory, that directory will be
+# included in the compiler include path.
+#
+# If any of these macros expand to a path which
+# contains a "lib/<arch>" directory, that directory will be
+# included in the compiler link path for that architecture.
+#
+# If your build fails, look for these paths in your build output
+# ==========================================================
+#MYMODULE=$(EPICS_MODULES)/asyn/$(MY_MODULE_VERSION)
+
+# Set EPICS_BASE last so it appears last in the DB, DBD, INCLUDE, and LIB search paths
+EPICS_BASE = $(EPICS_SITE_TOP)/base/$(BASE_MODULE_VERSION)
+
+# Check for invalid or undefined EPICS_BASE
+-include $(TOP)/../../EPICS_BASE.check

--- a/ioc.sh
+++ b/ioc.sh
@@ -2,7 +2,7 @@
 set -e
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
-cd iocBoot/sioc-temp-mon-test
+cd iocs/tempMonExampleIoc/iocBoot/sioc-temp-mon-test
 
 if [ -z "$EPICS_HOST_ARCH" ]; then
     echo "EPICS_HOST_ARCH not defined :("

--- a/launch-screen.sh
+++ b/launch-screen.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+pydm -m "P=MYIOC:" ./tempMonApp/op/pydm/cpu_temp.ui

--- a/tempMonApp/Db/CoreTemp.db
+++ b/tempMonApp/Db/CoreTemp.db
@@ -29,9 +29,9 @@ record(ai, "$(P)CPU_TEMP") {
 
     # --- Linear Conversion Parameters ---
 
-    # Use linear conversions
+    # Use linear conversions with explicit slope
     # The equation for this is: VAL = ESLO * VAL + EOFF
-    field(LINR, "LINEAR")
+    field(LINR, "SLOPE")
 
     # Raw value is in mC, so our slope should be 1/1000
     field(ESLO, "0.001")
@@ -58,8 +58,8 @@ record(ai, "$(P)CPU_TEMPF") {
     
     # --- Linear Conversion Parameters ---
 
-    # Use linear conversions
-    field(LINR, "LINEAR")
+    # Use linear conversions with explicit slope
+    field(LINR, "SLOPE")
 
     # Fahrenheit is given by:
     #  F = C * (9/5) + 32
@@ -86,7 +86,7 @@ record(ai, "$(P)CPU_MAX_TEMP") {
 
     # Same settings as CPU_TEMP
     field(ESLO, "0.001")
-    field(LINR, "LINEAR")
+    field(LINR, "SLOPE")
     field(EGU, "C")
 }
 
@@ -102,7 +102,7 @@ record(ai, "$(P)CPU_CRIT_TEMP") {
 
     # Same settings as CPU_TEMP
     field(ESLO, "0.001")
-    field(LINR, "LINEAR")
+    field(LINR, "SLOPE")
     field(EGU, "C")
 }
 


### PR DESCRIPTION
* Add uninstall rules, as requested by Marcio
* Update README with a bunch more info
* Use SLOPE instead of LINEAR for LINR field. I always get these confused; LINEAR technically requires the device support routines to compute ESLO/EOFF based on the EGUF/EGUL setting in the database. This bug went unnoticed because I wasn't touching ESLO/EOFF at all in special_linconv/record_init.


@marciodo review is optional :grin: 

Closes #4
